### PR TITLE
FEAT: Run ETL ECS Task from Github Action

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -14,6 +14,10 @@ inputs:
   role-to-assume:
     description: AWS_ROLE_ARN
     required: true
+  do-update-event-rule:
+    description: Update run event rule with new task?
+    required: true
+    default: 'true'
 
 runs:
   using: composite
@@ -37,4 +41,5 @@ runs:
         ECS_SERVICE: opmi-etl-${{ inputs.env-name }}
         ECS_TASK_DEF: opmi-etl-${{ inputs.env-name }}
         DOCKER_TAG: ${{ steps.build-push-ecr.outputs.docker-tag }}
+        DO_UPDATE_EVENT_RULE: ${{ inputs.do-update-event-rule }}
  

--- a/.github/actions/run_task/action.yaml
+++ b/.github/actions/run_task/action.yaml
@@ -1,0 +1,34 @@
+name: Manually Run ECS Task
+description: Run an existing task in an existing AWS Service and Cluster
+
+inputs:
+  role-to-assume:
+    description: IAM role
+    required: true
+  aws-region:
+    description: AWS region to use
+    required: true
+    default: us-east-1
+  cluster:
+    description: ECS Cluster for Service
+    required: true
+  service:
+    description: ECS Service for task to run
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
+    - name: Start ECS Task
+      run: ${{ github.action_path }}/run_task.sh
+      shell: bash
+      env:
+        AWS_REGION: ${{ inputs.aws-region }}
+        CLUSTER: ${{ inputs.cluster }}
+        SERVICE: ${{ inputs.service }}

--- a/.github/actions/run_task/run_task.sh
+++ b/.github/actions/run_task/run_task.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e -u
+
+# uncomment to debug
+# set -x
+
+# Run an ECS Task from the provided CLUSTER and SERVICE
+
+# required environment varialbes
+# - CLUSTER
+# - SERVICE
+
+# Get the Security Groups that can run the task.
+echo "Retrieving SecurityGroups for SERVICE:${SERVICE} in CLUSTER:${CLUSTER}"
+SECURITY_GROUPS=$(aws ecs describe-services \
+  --services $SERVICE \
+  --cluster $CLUSTER \
+  --query services[0].networkConfiguration.awsvpcConfiguration.securityGroups \
+  --output text \
+  | sed 's/\t/,/g')
+echo "SECURITY GROUPS: ${SECURITY_GROUPS}"
+
+# Get the Subnets that the task runs on.
+echo "Retrieving subnets for SERVICE:${SERVICE} in CLUSTER:${CLUSTER}"
+SUBNETS=$(aws ecs describe-services \
+  --services $SERVICE \
+  --cluster $CLUSTER \
+  --query services[0].networkConfiguration.awsvpcConfiguration.subnets \
+  --output text \
+  | sed 's/\t/,/g')
+echo "SUBNETS: ${SUBNETS}"
+
+# Run the ECS task
+aws ecs run-task \
+  --cluster $CLUSTER \
+  --task-definition $SERVICE \
+  --launch-type FARGATE \
+  --count 1 \
+  --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SECURITY_GROUPS],assignPublicIp=DISABLED}"

--- a/.github/workflows/deploy_and_run.yaml
+++ b/.github/workflows/deploy_and_run.yaml
@@ -1,0 +1,32 @@
+name: Deploy & Run
+
+on:
+  workflow_dispatch:
+    secrets:
+      AWS_ROLE_ARN:
+        description: AWS_ROLE_ARN
+        required: true
+
+jobs:
+  run_task:
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v3
+      - name: Deploy App
+        uses: ./.github/actions/deploy
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          docker-repo: ${{ secrets.DOCKER_URI }}
+          env-name: prod
+          do-update-event-rule: false
+      - name: Run Ad-Hoc Task
+        uses: ./.github/actions/run_task
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          cluster: 'opmi-etl'
+          service: 'opmi-etl-prod'


### PR DESCRIPTION
This change adds functionality to run the ETL ECS Task via github action from a selected branch. 

Will have to verify that this action does not impact the task definition that is being run by the schedule ETL task. 