### PR TITLE
Adding S&B API tables

### DIFF
--- a/src/research_etl/etl_sb_api/sb_api_job.py
+++ b/src/research_etl/etl_sb_api/sb_api_job.py
@@ -36,6 +36,8 @@ SB_TABLES = [
     sb_tables.sales_txns,
     sb_tables.validation_taps,
     sb_tables.shiftevent,
+    sb_tables.cashless_payments,
+    sb_tables.inspections,
 ]
 
 

--- a/src/research_etl/etl_sb_api/sb_tables.py
+++ b/src/research_etl/etl_sb_api/sb_tables.py
@@ -57,3 +57,15 @@ tvmtable = SBTable(
     table_type="static",
     part_column="",
 )
+
+cashless_payments = SBTable(
+    table_name="v_cashless_payments",
+    table_type="transaction",
+    part_column="requesttimestamp",
+)
+
+inspections = SBTable(
+    table_name="v_inspections",
+    table_type="transaction",
+    part_column="inquirytimestamp",
+)

--- a/tests/files/init_schema.sql
+++ b/tests/files/init_schema.sql
@@ -297,6 +297,63 @@ CREATE TABLE sb_api.v_tvmtable (
     , tvmcomment TEXT
 );
 
+CREATE TABLE sb_api.v_cashless_payments (
+    job_id BIGINT
+    , identity_value BIGINT
+    , merchantid TEXT
+    , chargeid BIGINT
+    , actionindex BIGINT
+    , actiontype TEXT
+    , capture BOOLEAN
+    , tapdebtrecovery BOOLEAN
+    , actionresult TEXT
+    , responsereferencecode TEXT
+    , paymentprovidererror TEXT
+    , requesttimestamp TIMESTAMP
+    , responsetimestamp TIMESTAMP
+    , tenant TEXT
+    , terminalid TEXT
+    , mediumid TEXT
+    , paymenttype TEXT
+    , paymentcardtype TEXT
+    , carddataentrymode TEXT
+    , transitmode BOOLEAN
+    , cardbrand TEXT
+    , cardbin TEXT
+    , cardmaskedpan TEXT
+    , paymentaccountreference TEXT
+    , servicereferenceid TEXT
+    , requestreferenceid TEXT
+    , responsetransactionnumber TEXT
+    , avsresponsecode TEXT
+    , cvvresponsecode TEXT
+    , amount BIGINT
+    , currency TEXT
+    , cardholderauthorizationmethod TEXT
+) PARTITION BY RANGE (requesttimestamp);
+
+CREATE INDEX ON sb_api.v_cashless_payments (requesttimestamp);
+
+CREATE TABLE sb_api.v_inspections (
+    job_id BIGINT
+    , identity_value BIGINT
+    , inspectionid BIGINT
+    , inquirytimestamp TIMESTAMP
+    , businessentityid BIGINT
+    , deviceid TEXT
+    , deviceclassid TEXT
+    , mediumid TEXT
+    , onlineprocessingstatus BOOLEAN
+    , preresult TEXT
+    , result TEXT
+    , overridereason TEXT
+    , inspectionstoppointid TEXT
+    , lineid TEXT
+    , servicepatternid TEXT
+) PARTITION BY RANGE (inquirytimestamp);
+
+CREATE INDEX ON sb_api.v_inspections (inquirytimestamp);
+
 -- ****************************************** --
 -- END INIT SB_API SCHEMA --
 -- ****************************************** --


### PR DESCRIPTION
I took a look through the code, commit history, and Notion, and I think I mostly understand how adding tables works. Based on this comment:
```
# The schema for these tables is defined in "tests/init_schema.sql"
# These tables are automatically created on a new build of the DEV docker postgres instance
#
# These tables must be manually created in the AWS Research Server DB. This database has no
# automated migration tooling. TID Infra Team has 'postgres' credentials that can be used to perform
# these manual steps.
```
it sounds like I need to edit `tests/init_schema.sql` so that the local tests will work, not do anything for dev, and log into the AWS Research Server DB and create these tables manually before I deploy these changes to prod. But I would like a second pair of eyes to make sure this seems like the right approach

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211787231826250