### PR TITLE
Fixing trailing slash issue

### DIFF
--- a/.github/actions/asdf_tools/action.yaml
+++ b/.github/actions/asdf_tools/action.yaml
@@ -14,7 +14,7 @@ runs:
     - name: Install ASDF Tools
       # only install if we can't find the cache (i.e. different os or new tools)
       if: "!steps.asdf-cache.outputs.cache-hit"
-      uses: asdf-vm/actions/install@v3
+      uses: asdf-vm/actions/install@v4
 
     - name: Re-Shim ASDF Install
       uses: mbta/actions/reshim-asdf@v1

--- a/.github/actions/asdf_tools/action.yaml
+++ b/.github/actions/asdf_tools/action.yaml
@@ -14,7 +14,7 @@ runs:
     - name: Install ASDF Tools
       # only install if we can't find the cache (i.e. different os or new tools)
       if: "!steps.asdf-cache.outputs.cache-hit"
-      uses: asdf-vm/actions/install@v2
+      uses: asdf-vm/actions/install@v3
 
     - name: Re-Shim ASDF Install
       uses: mbta/actions/reshim-asdf@v1

--- a/src/research_etl/etl_afc/afc_job.py
+++ b/src/research_etl/etl_afc/afc_job.py
@@ -194,11 +194,11 @@ def run(db_manager: DatabaseManager) -> None:
 
     list s3 objects from afc/in bucket and process any found files
 
-    each found file should temporarily downoladed locally for processsing and
+    each found file should temporarily downloaded locally for processing and
     then deleted
     """
-    s3_in_path = "afc_oracle_db"
-    s3_error_path = "afc_oracle_db_error"
+    s3_in_path = "afc_oracle_db/"
+    s3_error_path = "afc_oracle_db_error/"
     s3_in_bucket = os.getenv("AFC_IN_BUCKET", "")
 
     process_log = ProcessLogger("afc_etl_job")


### PR DESCRIPTION
Similar root issue to the [trailing slash issues in Odin](https://github.com/mbta/odin/pull/100).

Here, `afc_oracle_db` is matching objects in `afc_oracle_db_error`, resulting in an error where the server is trying to move objects from the `afc_oracle_db_error` location into itself (rather than `afc_oracle_db` -> `afc_oracle_db_error`)

---
Asana: https://app.asana.com/1/15492006741476/project/1208949713596457/task/1213994361477136?focus=true